### PR TITLE
MJEND-ES6-Syntax-Fixes

### DIFF
--- a/lib/qrcode-with-logos.common.js
+++ b/lib/qrcode-with-logos.common.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var QRCode = require('qrcode');
+import QRCode from 'qrcode';
 
 function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
 

--- a/src/draw-canvas.ts
+++ b/src/draw-canvas.ts
@@ -8,7 +8,7 @@ import { BaseOptions, NodeQrCodeOptions } from "../types/index";
 import { promisify } from "./utils";
 // @ts-ignore
 // import QRCode from "qrcode"
-const QRCode = require("qrcode")
+import QRCode from "qrcode"
 
 const toCanvas = promisify(QRCode.toCanvas);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@
 import { toCanvas } from "./toCanvas";
 import { toImage, saveImage } from "./toImage";
 import { BaseOptions } from "../types/index";
-const { version } = require('../package.json')
+import { version } from '../package.json';
 class QrCodeWithLogo {
 
   static version: string = version

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
       "module": "commonjs",
       "noImplicitAny": true,
       "removeComments": true,
+      "resolveJsonModule": true,
       "preserveConstEnums": true,
       "sourceMap": true,
       "allowJs": true


### PR DESCRIPTION
Hey, I was using this package an I could not load it with the ES5 syntax(aka the require) so I simply changed the syntax so users can use it with ES6 based products and I also thought it would be just better practice to do it like this 😁